### PR TITLE
App: Load Drip picture in absence of avatar

### DIFF
--- a/server/logic/profileData.js
+++ b/server/logic/profileData.js
@@ -3,6 +3,7 @@ const cardApi = require("../dal/cardApi");
 const imgApi = require("../dal/imgApi");
 const fetch = require("node-fetch");
 const util = require("util");
+const path = require("path");
 const readFile = util.promisify(require("fs").readFile);
 
 async function getProfile(id) {
@@ -19,7 +20,7 @@ async function getProfile(id) {
 
         if (userData.drip && userData.drip !== "NONE")
             responseData.drip = userData.drip;
-        
+
         // do they have a card?  If not, make one!
         if (!userData.card || userData.card === "NONE") {
             let dripBuffer;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,11 +10,14 @@
 	import Templates from './pages/Templates.svelte';
 
     export let url = '';
-    
+
     let userdata = {};
 
     onMount(async () => userdata = await userData());
     const toggleusermenu = () => jQuery(".usermenu").slideToggle();
+
+	// Load Discord image as fallback if avatar is not available
+    const loadgeneric = () => useravatar.src = "/css/img/discord.png";
 
 	const setTemplate = (id) => {
 		userdata.template = id;
@@ -53,7 +56,7 @@
 							</a>
 						</div>
 					</div>
-					<img src="{userdata.avatar}" on:click={toggleusermenu} alt="avatar" />
+					<img src="{userdata.avatar}" id="useravatar" on:click={toggleusermenu} on:error={loadgeneric} alt="avatar" />
 				</div>
 				<a class="btn btn-primary" href="/" role="button" use:link>Home</a>
 				<a class="btn btn-primary" href="/p/{userdata.profileId}" role="button" use:link>Profile</a>


### PR DESCRIPTION
When a user on Discord changes their profile image, the old image is removed from Discord's storage. Since the website records the avatar URL when a user authorizes a Discord login, there is no opportunity to read the new avatar URL later. The web page currently uses the alt-text `avatar` when it can't load the image.

This change causes the page to load the Drip picture in the avatar's absence. If the user has no drip picture, the placeholder Drip is loaded instead.

A cleaner solution would be connecting to Discord to re-read the avatar URL in case of a 404. I think this means either the access token needs to be re-issued, or the URL needs to be stored in the database.

While we're at it, add a missing include for `path` to profileData. Also strips some trailing spaces apparently.